### PR TITLE
Update main.ipynb

### DIFF
--- a/main.ipynb
+++ b/main.ipynb
@@ -11,28 +11,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this notebook, I will demonstrate how you can build a minimal private blockchain with essential operations such as \n",
+    "In this notebook, I will demonstrate how you can build a minimal private blockchain with essential operations such as:\n",
     "\n",
-    "a) creating a blockchain, \n",
-    "b) verifying a chain, \n",
-    "c) forking, and \n",
-    "d) comparing chains."
+    "a) creating a blockchain, b) verifying a chain, c) forking, and d) comparing chains."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 30,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-07-08T02:16:25.129422Z",
-     "start_time": "2019-07-08T02:16:25.125993Z"
+    "pycharm": {
+     "is_executing": false
     }
    },
    "outputs": [],
    "source": [
-    "import copy # fork a chain\n",
-    "import datetime # get real time for timestamps\n",
-    "import hashlib # hash"
+    "import copy  # fork a chain\n",
+    "import datetime  # get real time for timestamps\n",
+    "import hashlib  # hash\n",
+    "from enum import IntEnum\n",
+    "from datetime import timedelta  # used for obtaining time deltas between timestamps of blocks"
    ]
   },
   {
@@ -44,107 +42,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 31,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-07-08T02:16:42.235901Z",
-     "start_time": "2019-07-08T02:16:42.222441Z"
+    "pycharm": {
+     "is_executing": false
     }
    },
    "outputs": [],
    "source": [
-    "class MinimalChain():\n",
-    "    def __init__(self): # initialize when creating a chain\n",
-    "        self.blocks = [self.get_genesis_block()]\n",
-    "    \n",
-    "    def __eq__(self, other):\n",
-    "        if isinstance(other, self.__class__):\n",
-    "            return self.__dict__ == other.__dict__\n",
-    "        else:\n",
-    "            return False\n",
-    "    \n",
-    "    def get_genesis_block(self): \n",
-    "        return MinimalBlock(0, \n",
-    "                            datetime.datetime.utcnow(), \n",
-    "                            'Genesis', \n",
-    "                            'arbitrary')\n",
-    "    \n",
-    "    def add_block(self, data):\n",
-    "        self.blocks.append(MinimalBlock(len(self.blocks), \n",
-    "                                        datetime.datetime.utcnow(), \n",
-    "                                        data, \n",
-    "                                        self.blocks[len(self.blocks)-1].hash))\n",
-    "    \n",
-    "    def get_chain_size(self): # exclude genesis block\n",
-    "        return len(self.blocks)-1\n",
-    "    \n",
-    "    def verify(self, verbose=True): \n",
-    "        flag = True\n",
-    "        for i in range(1,len(self.blocks)):\n",
-    "            if not self.blocks[i].verify(): # assume Genesis block integrity\n",
-    "                flag = False\n",
-    "                if verbose:\n",
-    "                    print(f'Wrong data type(s) at block {i}.')\n",
-    "            if self.blocks[i].index != i:\n",
-    "                flag = False\n",
-    "                if verbose:\n",
-    "                    print(f'Wrong block index at block {i}.')\n",
-    "            if self.blocks[i-1].hash != self.blocks[i].previous_hash:\n",
-    "                flag = False\n",
-    "                if verbose:\n",
-    "                    print(f'Wrong previous hash at block {i}.')\n",
-    "            if self.blocks[i].hash != self.blocks[i].hashing():\n",
-    "                flag = False\n",
-    "                if verbose:\n",
-    "                    print(f'Wrong hash at block {i}.')\n",
-    "            if self.blocks[i-1].timestamp >= self.blocks[i].timestamp:\n",
-    "                flag = False\n",
-    "                if verbose:\n",
-    "                    print(f'Backdating at block {i}.')\n",
-    "        return flag\n",
-    "    \n",
-    "    def fork(self, head='latest'):\n",
-    "        if head in ['latest', 'whole', 'all']:\n",
-    "            return copy.deepcopy(self) # deepcopy since they are mutable\n",
-    "        else:\n",
-    "            c = copy.deepcopy(self)\n",
-    "            c.blocks = c.blocks[0:head+1]\n",
-    "            return c\n",
-    "    \n",
-    "    def get_root(self, chain_2):\n",
-    "        min_chain_size = min(self.get_chain_size(), chain_2.get_chain_size())\n",
-    "        for i in range(1,min_chain_size+1):\n",
-    "            if self.blocks[i] != chain_2.blocks[i]:\n",
-    "                return self.fork(i-1)\n",
-    "        return self.fork(min_chain_size)\n",
-    "    "
+    "# forking enums are used by the\n",
+    "# fork method of the MinimalChain\n",
+    "# class so the head input parm\n",
+    "# would be a consistent integer\n",
+    "class ForkingEnums(IntEnum):\n",
+    "    ALL = -1\n",
+    "    LATEST = -2\n",
+    "    WHOLE = -3"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 32,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-07-08T02:16:42.998711Z",
-     "start_time": "2019-07-08T02:16:42.990987Z"
+    "pycharm": {
+     "is_executing": false
     }
    },
    "outputs": [],
    "source": [
-    "class MinimalBlock():\n",
+    "class MinimalBlock:\n",
     "    def __init__(self, index, timestamp, data, previous_hash):\n",
     "        self.index = index\n",
     "        self.timestamp = timestamp\n",
     "        self.data = data\n",
     "        self.previous_hash = previous_hash\n",
     "        self.hash = self.hashing()\n",
-    "    \n",
+    "\n",
+    "    def __repr__(self):\n",
+    "        value = f'index: {self.index}, timestamp: {self.timestamp}, data: {self.data}, prev_hash: {self.previous_hash}, this_hash: {self.hash}'\n",
+    "        return value\n",
+    "\n",
     "    def __eq__(self, other):\n",
     "        if isinstance(other, self.__class__):\n",
     "            return self.__dict__ == other.__dict__\n",
     "        else:\n",
     "            return False\n",
-    "    \n",
+    "\n",
     "    def hashing(self):\n",
     "        key = hashlib.sha256()\n",
     "        key.update(str(self.index).encode('utf-8'))\n",
@@ -152,14 +95,96 @@
     "        key.update(str(self.data).encode('utf-8'))\n",
     "        key.update(str(self.previous_hash).encode('utf-8'))\n",
     "        return key.hexdigest()\n",
-    "    \n",
-    "    def verify(self): # check data types of all info in a block\n",
+    "\n",
+    "    def verify(self):  # check data types of all info in a block\n",
     "        instances = [self.index, self.timestamp, self.previous_hash, self.hash]\n",
     "        types = [int, datetime.datetime, str, str]\n",
     "        if sum(map(lambda inst_, type_: isinstance(inst_, type_), instances, types)) == len(instances):\n",
     "            return True\n",
     "        else:\n",
     "            return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "class MinimalChain:\n",
+    "    def __init__(self):  # initialize when creating a chain\n",
+    "        self.blocks = [MinimalChain.get_genesis_block()]\n",
+    "\n",
+    "    def __eq__(self, other):\n",
+    "        if isinstance(other, self.__class__):\n",
+    "            return self.__dict__ == other.__dict__\n",
+    "        else:\n",
+    "            return False\n",
+    "\n",
+    "    @staticmethod\n",
+    "    def get_genesis_block():\n",
+    "        return MinimalBlock(0,\n",
+    "                            datetime.datetime.utcnow(),\n",
+    "                            'Genesis',\n",
+    "                            'arbitrary')\n",
+    "\n",
+    "    def add_block(self, data):\n",
+    "        minimal_block = MinimalBlock(len(self.blocks),\n",
+    "                                     datetime.datetime.utcnow(),\n",
+    "                                     data,\n",
+    "                                     self.blocks[len(self.blocks) - 1].hash)\n",
+    "        self.blocks.append(minimal_block)\n",
+    "        print(minimal_block)\n",
+    "\n",
+    "    def get_chain_size(self):  # exclude genesis block\n",
+    "        return len(self.blocks) - 1\n",
+    "\n",
+    "    def verify(self, verbose=True):\n",
+    "        flag = True\n",
+    "        for ndx in range(1, len(self.blocks)):\n",
+    "            if not self.blocks[ndx].verify():  # assume Genesis block integrity\n",
+    "                flag = False\n",
+    "                if verbose:\n",
+    "                    print(f'Wrong data type(s) at block {ndx}.')\n",
+    "            if self.blocks[ndx].index != ndx:\n",
+    "                flag = False\n",
+    "                if verbose:\n",
+    "                    print(f'Wrong block index at block {ndx}.')\n",
+    "            if self.blocks[ndx - 1].hash != self.blocks[ndx].previous_hash:\n",
+    "                flag = False\n",
+    "                if verbose:\n",
+    "                    print(f'Wrong previous hash at block {ndx}.')\n",
+    "            if self.blocks[ndx].hash != self.blocks[ndx].hashing():\n",
+    "                flag = False\n",
+    "                if verbose:\n",
+    "                    print(f'Wrong hash at block {ndx}.')\n",
+    "            ts_curr = self.blocks[ndx].timestamp\n",
+    "            ts_prev = self.blocks[ndx - 1].timestamp\n",
+    "            ts_diff = (ts_curr - ts_prev) / timedelta(microseconds=1)\n",
+    "            if ts_diff < 0:\n",
+    "                flag = False\n",
+    "                if verbose:\n",
+    "                    print(f'Backdating at block {ndx}.')\n",
+    "        return flag\n",
+    "\n",
+    "    def fork(self, head=ForkingEnums.LATEST.value):\n",
+    "        if head in [ForkingEnums.LATEST.value, ForkingEnums.WHOLE.value, ForkingEnums.ALL.value]:\n",
+    "            return copy.deepcopy(self)  # deepcopy since they are mutable\n",
+    "        else:\n",
+    "            cpy = copy.deepcopy(self)\n",
+    "            cpy.blocks = cpy.blocks[0:head + 1]\n",
+    "            return cpy\n",
+    "\n",
+    "    def get_root(self, chain_2):\n",
+    "        min_chain_size = min(self.get_chain_size(), chain_2.get_chain_size())\n",
+    "        for i in range(1, min_chain_size + 1):\n",
+    "            if self.blocks[i] != chain_2.blocks[i]:\n",
+    "                return self.fork(i - 1)\n",
+    "        return self.fork(min_chain_size)"
    ]
   },
   {
@@ -171,109 +196,137 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 34,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-07-08T02:16:43.847119Z",
-     "start_time": "2019-07-08T02:16:43.844348Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "c = MinimalChain() # Start a chain\n",
-    "for i in range(1,20+1):\n",
-    "    c.add_block(f'This is block {i} of my first chain.')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-07-08T02:16:45.582222Z",
-     "start_time": "2019-07-08T02:16:45.578763Z"
+    "pycharm": {
+     "is_executing": false
     }
    },
    "outputs": [
     {
      "name": "stdout",
-     "output_type": "stream",
      "text": [
-      "2019-07-08 02:16:43.845600\n",
-      "This is block 7 of my first chain.\n",
-      "4d6fb1320bc8f58917060caf445c651c6dabc2f7df18fbb5c4908e1cf5453c97\n"
-     ]
+      "\nTesting...\n\n"
+     ],
+     "output_type": "stream"
     }
    ],
    "source": [
-    "print(c.blocks[3].timestamp)\n",
-    "print(c.blocks[7].data)\n",
-    "print(c.blocks[9].hash)\n"
+    "# Testing\n",
+    "\n",
+    "print('')\n",
+    "print('Testing...')\n",
+    "print('')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 35,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-07-08T02:16:46.278852Z",
-     "start_time": "2019-07-08T02:16:46.275505Z"
+    "pycharm": {
+     "is_executing": false
     }
    },
    "outputs": [
     {
      "name": "stdout",
-     "output_type": "stream",
      "text": [
-      "20\n",
-      "True\n"
-     ]
+      "index: 1, timestamp: 2019-09-27 19:05:41.473334, data: Block 1 of the chain., prev_hash: f1de49a0ea7474d46c423ae3674bea23abc98a94cdb18b84efe8958acf929593, this_hash: aaeca83893eb6003fdb6e347381b669f217d85f4f6fb240cd9670c19040eeb76\nindex: 2, timestamp: 2019-09-27 19:05:41.474334, data: Block 2 of the chain., prev_hash: aaeca83893eb6003fdb6e347381b669f217d85f4f6fb240cd9670c19040eeb76, this_hash: 3fdfd797da2bd34b3386168dd1799dec0b6652887b626d4ede82d804305409b8\nindex: 3, timestamp: 2019-09-27 19:05:41.474334, data: Block 3 of the chain., prev_hash: 3fdfd797da2bd34b3386168dd1799dec0b6652887b626d4ede82d804305409b8, this_hash: 4f28908f7e331b6e9683adce4031c23acc5bc7928d020973b072fd5b47725eb6\nindex: 4, timestamp: 2019-09-27 19:05:41.474334, data: Block 4 of the chain., prev_hash: 4f28908f7e331b6e9683adce4031c23acc5bc7928d020973b072fd5b47725eb6, this_hash: 961fb2a0868bd788f0202f6457ab751a42982938ba6e8e8f6d1ee1b7e5c97db3\nindex: 5, timestamp: 2019-09-27 19:05:41.474334, data: Block 5 of the chain., prev_hash: 961fb2a0868bd788f0202f6457ab751a42982938ba6e8e8f6d1ee1b7e5c97db3, this_hash: 9cbe9392aaae5df7329dd2d297e17997fa27c0731c066f6fe08d9271ef217cd4\nindex: 6, timestamp: 2019-09-27 19:05:41.474334, data: Block 6 of the chain., prev_hash: 9cbe9392aaae5df7329dd2d297e17997fa27c0731c066f6fe08d9271ef217cd4, this_hash: 0a0ccba9d6c8178a6267dfad5b9d022e5048aae9d984417196441a004bdc72ca\nindex: 7, timestamp: 2019-09-27 19:05:41.474334, data: Block 7 of the chain., prev_hash: 0a0ccba9d6c8178a6267dfad5b9d022e5048aae9d984417196441a004bdc72ca, this_hash: ceca264c2742ccb4ddfcf58d221a98c600b65e12f113ea1555b439ee563d7eee\nindex: 8, timestamp: 2019-09-27 19:05:41.475332, data: Block 8 of the chain., prev_hash: ceca264c2742ccb4ddfcf58d221a98c600b65e12f113ea1555b439ee563d7eee, this_hash: 7e5fd34f9d594011f99031b0ddf44368c063d03893fa06d59e12f651b51385ef\nindex: 9, timestamp: 2019-09-27 19:05:41.475332, data: Block 9 of the chain., prev_hash: 7e5fd34f9d594011f99031b0ddf44368c063d03893fa06d59e12f651b51385ef, this_hash: 50b3d614b3f5fbf4d62b1d2d9e3d5c3304e0d711c3a6ef5e075e23635dbe833c\nindex: 10, timestamp: 2019-09-27 19:05:41.475332, data: Block 10 of the chain., prev_hash: 50b3d614b3f5fbf4d62b1d2d9e3d5c3304e0d711c3a6ef5e075e23635dbe833c, this_hash: 620c0add3a9fd4353e1cec30de88d8f29655f36177b9575f933cfcc06ce15906\n"
+     ],
+     "output_type": "stream"
     }
    ],
    "source": [
-    "print(c.get_chain_size())\n",
-    "print(c.verify())"
+    "nbr_of_blocks = 10\n",
+    "\n",
+    "c = MinimalChain()  # Start a chain\n",
+    "for i in range(1, nbr_of_blocks + 1):\n",
+    "    c.add_block(f'Block {i} of the chain.')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 36,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-07-08T02:16:46.703246Z",
-     "start_time": "2019-07-08T02:16:46.699971Z"
+    "pycharm": {
+     "is_executing": false
     }
    },
    "outputs": [
     {
      "name": "stdout",
-     "output_type": "stream",
      "text": [
-      "True\n"
-     ]
+      "c.blocks[3].timestamp: 2019-09-27 19:05:41.474334\nc.blocks[7].data: Block 7 of the chain.\nc.blocks[9].hash: 50b3d614b3f5fbf4d62b1d2d9e3d5c3304e0d711c3a6ef5e075e23635dbe833c\n"
+     ],
+     "output_type": "stream"
     }
    ],
    "source": [
-    "c_forked = c.fork('latest')\n",
-    "print(c == c_forked)"
+    "print(f'c.blocks[3].timestamp: {c.blocks[3].timestamp}')\n",
+    "print(f'c.blocks[7].data: {c.blocks[7].data}')\n",
+    "print(f'c.blocks[9].hash: {c.blocks[9].hash}')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 37,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-07-08T02:16:47.076751Z",
-     "start_time": "2019-07-08T02:16:47.073328Z"
+    "pycharm": {
+     "is_executing": false
     }
    },
    "outputs": [
     {
      "name": "stdout",
-     "output_type": "stream",
      "text": [
-      "20 21\n"
-     ]
+      "c.get_chain_size(): 10\nVerifying 10 blocks...\nc.verify(): True\n"
+     ],
+     "output_type": "stream"
+    }
+   ],
+   "source": [
+    "print(f'c.get_chain_size(): {c.get_chain_size()}')\n",
+    "print(f'Verifying {c.get_chain_size()} blocks...')\n",
+    "print(f'c.verify(): {c.verify()}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "text": [
+      "c == c_forked: True\n"
+     ],
+     "output_type": "stream"
+    }
+   ],
+   "source": [
+    "c_forked = c.fork(ForkingEnums.LATEST.value)\n",
+    "print(f'c == c_forked: {c == c_forked}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "text": [
+      "index: 11, timestamp: 2019-09-27 19:05:41.521336, data: New block for forked chain!, prev_hash: 620c0add3a9fd4353e1cec30de88d8f29655f36177b9575f933cfcc06ce15906, this_hash: b849da382a501aa77280fbb2ccd80d75183d9a28f3bf66e189420328854790a1\n10 11\n"
+     ],
+     "output_type": "stream"
     }
    ],
    "source": [
@@ -290,105 +343,118 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 40,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-07-08T02:16:47.930832Z",
-     "start_time": "2019-07-08T02:16:47.921603Z"
+    "pycharm": {
+     "is_executing": false
     }
    },
    "outputs": [
     {
      "name": "stdout",
-     "output_type": "stream",
      "text": [
-      "Wrong block index at block 9.\n",
-      "Wrong hash at block 9.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
+      "\nConflict Testing...\n\n"
+     ],
+     "output_type": "stream"
     }
    ],
    "source": [
-    "c_forked = c.fork('latest')\n",
+    "# Conflict testing\n",
+    "\n",
+    "print('')\n",
+    "print('Conflict Testing...')\n",
+    "print('')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "text": [
+      "Wrong block index at block 9.\nWrong hash at block 9.\n"
+     ],
+     "output_type": "stream"
+    },
+    {
+     "data": {
+      "text/plain": "False"
+     },
+     "metadata": {},
+     "output_type": "execute_result",
+     "execution_count": 41
+    }
+   ],
+   "source": [
+    "c_forked = c.fork(ForkingEnums.LATEST.value)\n",
     "c_forked.blocks[9].index = -9\n",
     "c_forked.verify()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 42,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-07-08T02:16:49.119862Z",
-     "start_time": "2019-07-08T02:16:49.114159Z"
+    "pycharm": {
+     "is_executing": false
     }
    },
    "outputs": [
     {
      "name": "stdout",
-     "output_type": "stream",
      "text": [
-      "Wrong hash at block 16.\n",
-      "Backdating at block 16.\n"
-     ]
+      "Wrong hash at block 6.\nBackdating at block 6.\n"
+     ],
+     "output_type": "stream"
     },
     {
      "data": {
-      "text/plain": [
-       "False"
-      ]
+      "text/plain": "False"
      },
-     "execution_count": 10,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "execute_result",
+     "execution_count": 42
     }
    ],
    "source": [
-    "c_forked = c.fork('latest')\n",
-    "c_forked.blocks[16].timestamp = datetime.datetime(2000, 1, 1, 0, 0, 0, 0)\n",
+    "c_forked = c.fork(ForkingEnums.LATEST.value)\n",
+    "c_forked.blocks[6].timestamp = datetime.datetime(2000, 1, 1, 0, 0, 0, 0)\n",
     "c_forked.verify()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 43,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-07-08T02:16:49.519792Z",
-     "start_time": "2019-07-08T02:16:49.514132Z"
+    "pycharm": {
+     "is_executing": false
     }
    },
    "outputs": [
     {
      "name": "stdout",
-     "output_type": "stream",
      "text": [
-      "Wrong previous hash at block 5.\n",
-      "Wrong hash at block 5.\n"
-     ]
+      "Wrong previous hash at block 5.\nWrong hash at block 5.\n"
+     ],
+     "output_type": "stream"
     },
     {
      "data": {
-      "text/plain": [
-       "False"
-      ]
+      "text/plain": "False"
      },
-     "execution_count": 11,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "execute_result",
+     "execution_count": 43
     }
    ],
    "source": [
-    "c_forked = c.fork('latest')\n",
+    "c_forked = c.fork(ForkingEnums.LATEST.value)\n",
     "c_forked.blocks[5].previous_hash = c_forked.blocks[1].hash\n",
     "c_forked.verify()"
    ]
@@ -410,38 +476,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   },
-  "varInspector": {
-   "cols": {
-    "lenName": 16,
-    "lenType": 16,
-    "lenVar": 40
-   },
-   "kernels_config": {
-    "python": {
-     "delete_cmd_postfix": "",
-     "delete_cmd_prefix": "del ",
-     "library": "var_list.py",
-     "varRefreshCmd": "print(var_dic_list())"
-    },
-    "r": {
-     "delete_cmd_postfix": ") ",
-     "delete_cmd_prefix": "rm(",
-     "library": "var_list.r",
-     "varRefreshCmd": "cat(var_dic_list()) "
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "source": [],
+    "metadata": {
+     "collapsed": false
     }
-   },
-   "types_to_exclude": [
-    "module",
-    "function",
-    "builtin_function_or_method",
-    "instance",
-    "_Feature"
-   ],
-   "window_display": false
+   }
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Tweaked the verify() method in the MiminalChain class as the backdating check's if clause comparison of block timestamps was reversed, rendering a result that the current block's timestamp was backdated compared to the previous block's timestamp, when in reality it was not.
Added the ForkingEnums class so that the fork() method's head parameter would be a consistent integer, rather than a mixture of string and integer.
Reduced the number of test blocks generated to 10 instead of 20, adjusting hardcoded indexes to accommodate this change as needed. 
Add a __repr__ method to the MinimalBlock class to facilitate easy printing of the block, useful when one wishes to print a block to the console.